### PR TITLE
cli.js --browsers: default to null

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -20,7 +20,7 @@ var yargs = require('yargs')
   .options('b', {
     alias: 'browsers',
     description: 'Autoprefixer-like browser criteria.',
-    default: browserslist.defaults.join(', ')
+    default: null // browserslist.defaults.join(', ')
   })
   .string('b')
   .options('i', {
@@ -73,7 +73,7 @@ if (argv.config) {
   }
 }
 
-argv.browsers = argv.browsers.split(',').map(function (s) { return s.trim() })
+argv.browsers && (argv.browsers = argv.browsers.split(',').map(function (s) { return s.trim() }))
 argv.ignore = argv.ignore.split(',').map(function (s) { return s.trim() })
 // Informational output
 if (argv.l) { argv.v = ++argv.verbose }


### PR DESCRIPTION
This let browserslist pick up a '.browserslistrc' if no browsers are
provided. If such a file is not found it will default to
browserslist.defaults anyway.

This way 'doiuse' in cli mode can pick up '.browserslistrc' as expected.
Note: this depends on my previous PR.